### PR TITLE
Add href attribute to recipe links

### DIFF
--- a/scripts/templates/home.js
+++ b/scripts/templates/home.js
@@ -97,7 +97,7 @@ function HomeTemplate (id, rect) {
       html += "<ul style='margin-bottom:15px'>"
       for (id in recipes) {
         var recipe = recipes[id]
-        html += `<li><a onclick="Ø('query').bang('${recipe.name.capitalize()}')">${recipe.name.capitalize()}</a></li>`
+        html += `<li><a href="#${recipe.name.to_url()}" onclick="Ø('query').bang('${recipe.name.capitalize()}')">${recipe.name.capitalize()}</a></li>`
       }
       html += '</ul>'
     }


### PR DESCRIPTION
Links for recipes didn't have a href link. This was annoying for accessibility and for useful links features (ie: open in a new tab)