### PR TITLE
Add Javascript warnings

### DIFF
--- a/404.html
+++ b/404.html
@@ -7,12 +7,24 @@ permalink: /404.html
   <meta charset="utf-8">
   <title>Loading..</title>
 </head>
-<body style='background:black'>
+<body style='background:black; color:white'>
   <script>
     var parts = window.location.pathname.split("/")
     var target = parts.slice(-1);
     parts.splice(-1)
     document.location.href = parts.join("/")+"/#"+target
   </script>
+  
+  <h1>
+    Loading, please wait.
+    <br />
+    If this takes a long time, please check your Javascript settings.
+  </h1>
+  
+  <noscript>
+    <h2>
+      This website requires Javascript. To view the content, please enable it in your browser settings.
+    </h2>
+  </noscript>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -51,5 +51,11 @@
     var RIVEN = new Riven();
     graph()
   </script>
+  
+  <noscript>
+    <h2 style="color:white">
+      This website requires Javascript. To view the content, please enable it in your browser settings.
+    </h2>
+  </noscript>
 </body>
 </html>


### PR DESCRIPTION
Current behaviour for `index.html` and `404.html` is to display a black screen if JS is disabled. This fixes that in two ways:

- Both pages have a `<noscript>` message to warn the user and tell them how to fix the issue
- The 404 page has an always-displaying message telling users what to do if the redirect fails

Something I would like is for the 404 page text to only display after a certain period of time. This could be done with CSS animations (I'll look into it soon).