### PR TITLE
bugfix: convert recipe name to url on the ingredient pages

### DIFF
--- a/scripts/templates/ingredient.js
+++ b/scripts/templates/ingredient.js
@@ -101,7 +101,7 @@ function IngredientTemplate (id, rect) {
       var name = id
       html += `
       <li class='recipe'>
-        <a onclick="Ø('query').bang('${name}')" class='photo' href='#${name}' style='background-image:url(media/recipes/${name.to_path()}.jpg)'></a>
+        <a onclick="Ø('query').bang('${name}')" class='photo' href='#${name.to_url()}' style='background-image:url(media/recipes/${name.to_path()}.jpg)'></a>
         <t class='name'>${name.capitalize()}</t>
         <t class='details'><b>${recipe.TIME} minutes</b><br />${count_ingredients(recipe)} ingredients<br />${recipe.INST.length} steps</t>
       </li>`


### PR DESCRIPTION
right now if you go to an ingredient, then click on a recipe (that has spaces in the name) on that page, it'll go to the 404 page. This update fixes it by calling `to_url` to replace the spaces with +