### PR TITLE
Add ingredient warnings

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -65,6 +65,9 @@ h1,h2,h3,h4 { font-weight: normal; font-family: 'alte_haas_grotesk_bold'; margin
 #view #core #content #instructions i { background: #eee;font-size: 12px;text-transform: uppercase;padding: 5px 7.5px;display: inline-block;font-weight: bold;border-radius: 3px;color: #333;line-height: 15px }
 #view #core #content #instructions code { font-size: 12px;text-transform: uppercase;padding: 3px 5.5px;display: inline-block;font-weight: bold;border-radius: 3px;border: 2px solid black;line-height: 15px}
 
+#view #core #content #warn p { border-left: 3px solid orangered; padding-left: 7px; }
+#view #core #content #warn p::before { content: 'Warning: '; font-weight: bold; }
+
 #view #core #content ul.ingredients { display: inline-block; margin-right:15px; font-size:0; padding-left:20px; margin-bottom:30px; }
 #view #core #content ul.ingredients h3 { margin-left:-20px; }
 #view #core #content ul.ingredients li.ingredient { width: 100px;margin-left:-20px;min-height: 210px;display: inline-block;text-align: center;vertical-align: top;border: 2px dashed transparent;border-radius: 10px; }

--- a/scripts/database/ingredients.ndtl
+++ b/scripts/database/ingredients.ndtl
@@ -116,6 +116,8 @@ Wakame
   BREF : Wakame is a very invasive plant - it's even banned in Australia.
 Dried Hijiki
   PARENT : Seaweed
+  WARN
+    & Consumption of only a small amount of hijiki seaweed could result in an intake of inorganic arsenic that exceeds the tolerable daily intake for this substance. Therefore, consumption of this type of seaweed is to be avoided. See also the {{Canadian Food Inspection Agency|http://www.inspection.gc.ca/food/information-for-consumers/fact-sheets-and-infographics/products-and-risks/chemical-hazards/inorganic-arsenic/eng/1332268146718/1332268231124}}.
 Bull kelp powder
   PARENT : Seaweed
 Nori
@@ -527,7 +529,8 @@ Bamboo charcoal powder
   LONG
     & Bamboo charcoal comes from pieces of bamboo plants, harvested after at least five years, and burned in ovens at temperatures ranging from {#800 °C#} to {#1200 °C#}.
     & It benefits environmental protection by reducing pollutant residue. It is an environmentally functional material featuring excellent absorption properties. It can be added to foods to give it a black tint, it's very popular in Japan. You can get some through Taketora, a japanese company. (wikipedia description).
-    & {*Important note*}: Bamboo charcoal binds on the nutrients in food that you're meant to be digesting, so it's preferable to not add bamboo charcoal to every food you make. Use it sparingly, as an occasional treat.
+  WARN
+    & Bamboo charcoal binds on the nutrients in food that you're meant to be digesting, so it's preferable to not add bamboo charcoal to every food you make. Use it sparingly, as an occasional treat.
 Cornstarch
 Active dry yeast
 Baking soda

--- a/scripts/database/recipes.ndtl
+++ b/scripts/database/recipes.ndtl
@@ -510,7 +510,6 @@ DARK YAKI GYOZA
     & We had a lot of fun making these gyoza, it's best made and eaten with friends!
     % recipes/dark.yaki.gyoza.5.jpg
     & Gyoza wrapper techniques and ratios were based on the recipe from {{Just one cookbook|http://www.justonecookbook.com/recipes/gyoza-wrappers/}}. She explains it really well too on her blog it's worth taking a look. I learned a lot from her even if our techniques differ slightly. While I preferred not to knead by hand, or with a rolling pin, i did do it her way the first time.
-    & NOTE: Bamboo charcoal binds on the nutrients in food that you're meant to be digesting, so it's preferable to not add bamboo charcoal to every food you make. Use it sparingly, as an occasional treat.
   INST
     Dough
       - Mix {_2 cups_} of {{all purpose flour}} with {_1 tsp_} of {{bamboo charcoal powder}} in a bowl.
@@ -711,7 +710,6 @@ BASIC BLACK BREAD
     & I made this loaf for a brunch I had with friends, we wanted to have fondue with a set I got as a gift during the holidays. We  cut the loaf into cubes, and dunked them in! Soft bread is perfect for fondue!
     % recipes/basic.black.bread.2.jpg
     & So there you have it! A basic black bread!
-    & NOTE: Bamboo charcoal binds on the nutrients in food that you're meant to be digesting, so it's preferable to not add bamboo charcoal to every food you make. Use it sparingly, as an occasional treat.
   INST
     Loaf
       - In a large bowl, stir {_1 1/2 tsp_} of {{salt}} and {_3/4 tbsp_} of {{maple syrup}} in {_1 cup_} of {{warm water}} until dissolved. Sprinkle tsp of {{active dry yeast}}, let sit for {#10 minutes#}.
@@ -818,7 +816,6 @@ POTATO GNOCCHI
     & These turned out perfect! This is a large recipe, so if you're only two you'll have plenty left-over that you can let dry, freeze and eat later.
     % recipes/potato.gnocchi.2.jpg
     & Because the sauce and toppings are light and simple, you can focus on the texture of the gnocchi.
-    & NOTE: {*Bamboo charcoal*} binds on the nutrients in food that you're meant to be digesting, so it's preferable to not add bamboo charcoal to every food you make. Use it sparingly, as an occasional treat.
   INST
     Gnocchi
       - Preheat oven to {#400F#}.
@@ -1189,7 +1186,6 @@ FRENCH TOAST
     & You can make your own soft bread using my {{Basic black bread}} recipe - it's very easy to make. You can omit the {{bamboo charcoal}} if you don't want your dough to be black.
     & Using bananas makes for a consistent morning meal, and adds a bit of sweetness to it. Bananas become sweeter when heated in a pan, they caramelize and develop a very pleasant taste. Adding a banana to the soy milk helps to thicken the mix and will make the bread become a 'golden' color.
     % recipes/french.toast.2.jpg
-    & NOTE: {*Bamboo charcoal*} binds on the nutrients in food that you're meant to be digesting, so it's preferable to not add bamboo charcoal to every food you make. Use it sparingly, as an occasional treat.
   INST
     Preparation
       - Purée {_1_} {{banana}}, {_3/4 cup_} of {{soy milk}} and {_1/2 tsp_} of {{vanilla extract}}.
@@ -1259,7 +1255,6 @@ UZUMAKI HUMMUS BITES
     & Making tortillas at home is damn easy, it doesn't require a lot of waiting time or preparation. The only thing I had trouble with, was making them into nice circular shapes. The easy way is to use a tortilla press, or it just requires lots of practice.
     % recipes/uzumaki.hummus.bites.3.jpg
     & Making the tortillas black is optional, but it adds a nice contrast to the beet hummus. 
-    & NOTE: {*Bamboo charcoal*} binds on the nutrients in food that you're meant to be digesting, so it's preferable to not add bamboo charcoal to every food you make. Use it sparingly, as an occasional treat.
   INST
     Beet hummus
       - Preheat oven to {#375F#}.

--- a/scripts/templates/ingredient.js
+++ b/scripts/templates/ingredient.js
@@ -25,6 +25,7 @@ function IngredientTemplate (id, rect) {
     html += `<h1>${name.capitalize()}</h1>`
     html += ingredient.BREF ? `<p class='bref'>${ingredient.BREF.to_markup()}</p>` : ''
     html += ingredient.LONG ? `${new Runic(ingredient.LONG)}` : ''
+    html += ingredient.WARN ? `<section id='warn'>${new Runic(ingredient.WARN)}</section>` : ''
     html += `${make_parents(ingredient)}`
     html += `${make_children(name, all_ingredients)}`
     html += `${make_similar(name, recipes, all_ingredients)}`

--- a/scripts/templates/recipe.js
+++ b/scripts/templates/recipe.js
@@ -36,6 +36,7 @@ function RecipeTemplate (id, rect) {
 
     <columns>${new Runic(recipe.DESC)}</columns>
     ${make_ingredients(recipe.INGR)}
+    ${make_warnings(recipe, q.tables.ingredients)}
     ${make_instructions(recipe)}`
 
     return html
@@ -55,6 +56,25 @@ function RecipeTemplate (id, rect) {
     }
 
     return `<div id='instructions'>${html}</div>`
+  }
+
+  function make_warnings (recipe, all_ingredients) {
+    let html = ''
+
+    for (cat in recipe.INGR) {
+      for (id in recipe.INGR[cat]) {
+        if (all_ingredients[id].WARN) {
+          const warn = all_ingredients[id].WARN
+          html += `
+            <section id='warn'>
+              ${new Runic(warn)}
+            </section>
+          `
+        }
+      }
+    }
+
+    return html
   }
 
   function formatTemperature (temperature) {


### PR DESCRIPTION
This PR adds a `WARN` field to ingredients. When viewing an ingredient with a warning, or any recipe using that ingredient, the warning is displayed prominently.
Each paragraph of `WARN` is its own warning, and they have a nice orange bar to the left of them.

Also, this PR adds `WARN` fields to bamboo charcoal powder and hijiki.