### PR TITLE
Fixed recipes texts being 2 columns on mobile

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -83,4 +83,5 @@ body.home nav ul li.home, body.about nav ul li.about, body.tools nav ul li.tools
 @media (max-width: 850px) {
   main ul.recipes { columns:1; }
   main p.col2 { columns:1; }
+  main > div.col2 { columns: 1; }
 }


### PR DESCRIPTION
On mobile the recipe description is split in two columns, making the text very hard to read. I added the change in an existing media query to bring consistency.