### PR TITLE
Apply border style to lactofermentation nav item

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -86,7 +86,7 @@ main > table.col b { font-weight: bold }
 
 main img.characters {max-width: 100px;}
 
-body.home nav ul li.home, body.about nav ul li.about, body.tools nav ul li.tools, body.nutrition nav ul li.nutrition, body.sprouting nav ul li.sprouting { border-bottom-color: black }
+body.home nav ul li.home, body.about nav ul li.about, body.tools nav ul li.tools, body.nutrition nav ul li.nutrition, body.sprouting nav ul li.sprouting, body.lactofermentation nav ul li.lactofermentation { border-bottom-color: black }
 
 @media (max-width: 650px){
   main ul.recipes { columns:1 }


### PR DESCRIPTION
## What does this do?

* Applies the border styling to the nav item for lactofermentation when on the lactofermentation page

## Screenshots

### Before

<img width="642" alt="Screenshot 2022-03-29 at 14 27 03" src="https://user-images.githubusercontent.com/705427/160621975-118c379c-507e-424a-99c9-8dd9d2c7a30a.png">

### After

<img width="594" alt="Screenshot 2022-03-29 at 14 29 10" src="https://user-images.githubusercontent.com/705427/160622289-1f2a5eb3-b899-4997-b212-46b4408a318f.png">